### PR TITLE
[codex] Prepare license notice and 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 - 2026-06-24
+
+- Initial Swift Package release.
+- Includes the bundled `humation-1` asset set.
+- Renders deterministic Humation avatars with Core Graphics, without WebView or network access.
+- Supports iOS 15+, macOS 12+, tvOS 15+, and visionOS 1+.

--- a/LICENSE
+++ b/LICENSE
@@ -2,11 +2,6 @@ MIT License
 
 Copyright (c) 2026 Mana
 
-This is a native Swift port of Humation (https://github.com/humation-labs/humation),
-a deterministic hand-drawn SVG avatar engine. The bundled asset set
-(`humation-1`) and its design originate from that project and remain under its
-MIT license.
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+Humation Swift
+
+This is a native Swift port of Humation:
+https://github.com/humation-labs/humation
+
+The bundled asset set (`humation-1`) and its design originate from Humation
+and are licensed under MIT.


### PR DESCRIPTION
## Summary
- keep LICENSE as standard MIT text so GitHub can detect it cleanly
- move Humation attribution into NOTICE
- add CHANGELOG.md with initial 1.0.0 release notes

## Validation
- swift test