### PR TITLE
Add circular avatar rendering and PNG data output

### DIFF
--- a/Sources/Humation/Render/HumationCaches.swift
+++ b/Sources/Humation/Render/HumationCaches.swift
@@ -73,16 +73,28 @@ actor HumationImageProvider {
     }
 
     nonisolated static func cacheKey(
-        _ resolved: ResolvedHumation, pixels: Int, crop: HumationManifest.ViewBox? = nil
+        _ resolved: ResolvedHumation,
+        pixels: Int,
+        crop: HumationManifest.ViewBox? = nil,
+        shape: HumationAvatarShape = .square
     ) -> String {
         let cropKey = crop.map { "\($0.x)_\($0.y)_\($0.width)_\($0.height)" } ?? "avatar"
-        return "humation:\(resolved.cacheToken)@\(pixels)#\(cropKey)"
+        let base = "humation:\(resolved.cacheToken)@\(pixels)#\(cropKey)"
+        switch shape {
+        case .square:
+            return base
+        case .circle:
+            return "\(base)|circle"
+        }
     }
 
     func image(
-        for resolved: ResolvedHumation, pixels: Int, crop: HumationManifest.ViewBox? = nil
+        for resolved: ResolvedHumation,
+        pixels: Int,
+        crop: HumationManifest.ViewBox? = nil,
+        shape: HumationAvatarShape = .square
     ) async -> CGImage? {
-        let key = Self.cacheKey(resolved, pixels: pixels, crop: crop)
+        let key = Self.cacheKey(resolved, pixels: pixels, crop: crop, shape: shape)
 
         if let cached = Self.memoryImage(forKey: key) { return cached }
         if let inFlight = pending[key] { return await inFlight.value }
@@ -91,7 +103,11 @@ actor HumationImageProvider {
             guard let manifest = HumationManifestStore.shared else { return nil }
             guard
                 let image = HumationRenderer.render(
-                    resolved: resolved, manifest: manifest, pixels: pixels, crop: crop
+                    resolved: resolved,
+                    manifest: manifest,
+                    pixels: pixels,
+                    crop: crop,
+                    shape: shape
                 )
             else { return nil }
             Self.bitmapCache.setObject(image, forKey: key as NSString, cost: pixels * pixels * 4)

--- a/Sources/Humation/Render/HumationRenderer.swift
+++ b/Sources/Humation/Render/HumationRenderer.swift
@@ -1,5 +1,7 @@
 import CoreGraphics
 import Foundation
+import ImageIO
+import UniformTypeIdentifiers
 
 #if canImport(UIKit)
 import UIKit
@@ -21,6 +23,11 @@ import AppKit
 // Pure and thread-agnostic — safe to call from the image-provider actor or
 // synchronously.
 
+public enum HumationAvatarShape: Sendable {
+    case square
+    case circle
+}
+
 public enum HumationRenderer {
 
     /// Render at an exact pixel size to a `CGImage` (cross-platform).
@@ -33,10 +40,12 @@ public enum HumationRenderer {
         resolved: ResolvedHumation,
         manifest: HumationManifest,
         pixels: Int,
-        crop: HumationManifest.ViewBox? = nil
+        crop: HumationManifest.ViewBox? = nil,
+        shape: HumationAvatarShape = .square
     ) -> CGImage? {
         let crop = crop ?? manifest.avatarCrop
         let side = CGFloat(pixels)
+        let rect = CGRect(x: 0, y: 0, width: side, height: side)
         let scale = side / CGFloat(crop.width) // crop is square
 
         let isOpaque = resolved.background != "transparent"
@@ -54,13 +63,20 @@ public enum HumationRenderer {
             )
         else { return nil }
 
+        ctx.clear(rect)
+
         // Flip into SVG's top-left, y-down space.
         ctx.translateBy(x: 0, y: side)
         ctx.scaleBy(x: 1, y: -1)
 
+        if shape == .circle {
+            ctx.addEllipse(in: rect)
+            ctx.clip()
+        }
+
         if isOpaque, let bg = HumationRGBA(hex: resolved.background) {
             ctx.setFillColor(bg.cgColor)
-            ctx.fill(CGRect(x: 0, y: 0, width: side, height: side))
+            ctx.fill(rect)
         }
 
         // World → pixel: scale, then shift the crop origin to (0,0).
@@ -89,9 +105,13 @@ public enum HumationRenderer {
         resolved: ResolvedHumation,
         manifest: HumationManifest,
         pixels: Int,
-        crop: HumationManifest.ViewBox? = nil
+        crop: HumationManifest.ViewBox? = nil,
+        shape: HumationAvatarShape = .square
     ) -> UIImage? {
-        guard let cg = render(resolved: resolved, manifest: manifest, pixels: pixels, crop: crop)
+        guard
+            let cg = render(
+                resolved: resolved, manifest: manifest, pixels: pixels, crop: crop, shape: shape
+            )
         else { return nil }
         return UIImage(cgImage: cg)
     }
@@ -103,13 +123,43 @@ public enum HumationRenderer {
         resolved: ResolvedHumation,
         manifest: HumationManifest,
         pixels: Int,
-        crop: HumationManifest.ViewBox? = nil
+        crop: HumationManifest.ViewBox? = nil,
+        shape: HumationAvatarShape = .square
     ) -> NSImage? {
-        guard let cg = render(resolved: resolved, manifest: manifest, pixels: pixels, crop: crop)
+        guard
+            let cg = render(
+                resolved: resolved, manifest: manifest, pixels: pixels, crop: crop, shape: shape
+            )
         else { return nil }
         return NSImage(cgImage: cg, size: NSSize(width: pixels, height: pixels))
     }
     #endif
+
+    /// PNG data convenience for notification-extension image payloads.
+    public static func pngData(
+        resolved: ResolvedHumation,
+        manifest: HumationManifest,
+        pixels: Int,
+        crop: HumationManifest.ViewBox? = nil,
+        shape: HumationAvatarShape = .square
+    ) -> Data? {
+        guard
+            let cg = render(
+                resolved: resolved, manifest: manifest, pixels: pixels, crop: crop, shape: shape
+            )
+        else { return nil }
+
+        let data = NSMutableData()
+        guard
+            let destination = CGImageDestinationCreateWithData(
+                data, UTType.png.identifier as CFString, 1, nil
+            )
+        else { return nil }
+
+        CGImageDestinationAddImage(destination, cg, nil)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return data as Data
+    }
 
     /// World-space bounding box of a part's drawn content (path bounds + stroke
     /// allowance, offset by its layer). Lets callers frame a part tightly without

--- a/Tests/HumationTests/HumationTests.swift
+++ b/Tests/HumationTests/HumationTests.swift
@@ -69,6 +69,61 @@ final class HumationTests: XCTestCase {
         XCTAssertEqual(image.height, 128)
     }
 
+    func testCircleRenderClipsCornersToTransparent() throws {
+        let manifest = try XCTUnwrap(HumationManifestStore.shared)
+        let resolved = opaqueResolved(against: manifest)
+        let image = try XCTUnwrap(
+            HumationRenderer.render(
+                resolved: resolved, manifest: manifest, pixels: 64, shape: .circle
+            )
+        )
+
+        XCTAssertEqual(try alpha(in: image, x: 0, y: 0), 0)
+        XCTAssertEqual(try alpha(in: image, x: 63, y: 0), 0)
+        XCTAssertEqual(try alpha(in: image, x: 0, y: 63), 0)
+        XCTAssertEqual(try alpha(in: image, x: 63, y: 63), 0)
+        XCTAssertEqual(try alpha(in: image, x: 32, y: 32), 255)
+    }
+
+    func testSquareRenderKeepsCornersOpaque() throws {
+        let manifest = try XCTUnwrap(HumationManifestStore.shared)
+        let resolved = opaqueResolved(against: manifest)
+        let image = try XCTUnwrap(
+            HumationRenderer.render(
+                resolved: resolved, manifest: manifest, pixels: 64, shape: .square
+            )
+        )
+
+        XCTAssertEqual(try alpha(in: image, x: 0, y: 0), 255)
+        XCTAssertEqual(try alpha(in: image, x: 63, y: 0), 255)
+        XCTAssertEqual(try alpha(in: image, x: 0, y: 63), 255)
+        XCTAssertEqual(try alpha(in: image, x: 63, y: 63), 255)
+    }
+
+    func testPNGDataStartsWithPNGMagicBytes() throws {
+        let manifest = try XCTUnwrap(HumationManifestStore.shared)
+        let resolved = opaqueResolved(against: manifest)
+        let data = try XCTUnwrap(
+            HumationRenderer.pngData(
+                resolved: resolved, manifest: manifest, pixels: 64, shape: .circle
+            )
+        )
+
+        XCTAssertEqual(Array(data.prefix(4)), [0x89, 0x50, 0x4E, 0x47])
+    }
+
+    func testImageProviderCacheKeyIncludesShape() throws {
+        let manifest = try XCTUnwrap(HumationManifestStore.shared)
+        let resolved = opaqueResolved(against: manifest)
+
+        let legacy = HumationImageProvider.cacheKey(resolved, pixels: 64)
+        let square = HumationImageProvider.cacheKey(resolved, pixels: 64, shape: .square)
+        let circle = HumationImageProvider.cacheKey(resolved, pixels: 64, shape: .circle)
+
+        XCTAssertEqual(square, legacy)
+        XCTAssertNotEqual(circle, square)
+    }
+
     func testBundledManifestIsValid() throws {
         let manifest = try XCTUnwrap(HumationManifestStore.shared)
         let issues = HumationValidator.validate(manifest)
@@ -92,5 +147,40 @@ final class HumationTests: XCTestCase {
         if let none = manifest.parts(in: .item).first(where: { $0.name == "none" }) {
             XCTAssertNil(HumationRenderer.contentBounds(of: none, in: manifest))
         }
+    }
+
+    private func opaqueResolved(against manifest: HumationManifest) -> ResolvedHumation {
+        HumationTraits(colors: [.background: "FF00AA"], seed: "render-shape")
+            .resolved(against: manifest)
+    }
+
+    private func alpha(in image: CGImage, x: Int, y: Int) throws -> UInt8 {
+        let bytesPerPixel = 4
+        let bytesPerRow = image.width * bytesPerPixel
+        var bytes = [UInt8](repeating: 0, count: bytesPerRow * image.height)
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        let ok = bytes.withUnsafeMutableBytes { buffer -> Bool in
+            guard
+                let baseAddress = buffer.baseAddress,
+                let ctx = CGContext(
+                    data: baseAddress,
+                    width: image.width,
+                    height: image.height,
+                    bitsPerComponent: 8,
+                    bytesPerRow: bytesPerRow,
+                    space: colorSpace,
+                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                )
+            else { return false }
+
+            ctx.interpolationQuality = .none
+            ctx.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+            ctx.flush()
+            return true
+        }
+        XCTAssertTrue(ok)
+
+        let index = (y * bytesPerRow) + (x * bytesPerPixel) + 3
+        return bytes[index]
     }
 }


### PR DESCRIPTION
## Summary
- **`HumationAvatarShape`** (`.square` / `.circle`) parameter on `HumationRenderer.render` / `image` / `nsImage`, defaulting to `.square` (fully backward compatible). `.circle` clips the background fill and all parts to an ellipse, leaving transparent corners.
- **`pngData(resolved:manifest:pixels:crop:shape:)`** — PNG encoding via ImageIO / UniformTypeIdentifiers (no UIKit/AppKit dependency), for notification-extension payloads (`INImage(imageData:)` in communication notifications).
- **Cache keys** include the shape; `.square` keys keep the legacy string format so existing cached entries stay valid.

Extracted from a production notification service extension (DopaDopa) that hand-rolled the ellipse clip + PNG conversion for INSendMessageIntent avatars.

## Test plan
- `swift test` — 13 tests pass (4 new: circle corner alpha = 0 with opaque background, square corners opaque, PNG magic bytes, shape-distinct cache keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)