### PR TITLE
Add HumationEditor: themeable avatar builder UI (new library product)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     ],
     products: [
         .library(name: "Humation", targets: ["Humation"]),
+        .library(name: "HumationEditor", targets: ["HumationEditor"]),
     ],
     targets: [
         .target(
@@ -19,9 +20,17 @@ let package = Package(
                 .copy("Resources/humation-1.json"),
             ]
         ),
+        .target(
+            name: "HumationEditor",
+            dependencies: ["Humation"]
+        ),
         .testTarget(
             name: "HumationTests",
             dependencies: ["Humation"]
+        ),
+        .testTarget(
+            name: "HumationEditorTests",
+            dependencies: ["Humation", "HumationEditor"]
         ),
     ]
 )

--- a/Sources/Humation/Example/HumationEditorExample.swift
+++ b/Sources/Humation/Example/HumationEditorExample.swift
@@ -5,6 +5,8 @@ import SwiftUI
 // A self-contained "build your avatar" editor built only with SwiftUI + Humation
 // (no app dependencies). Demonstrates the full flow: live preview, per-slot part
 // grid, colour swatches, and randomise. Drop it into any app or preview it as-is.
+// For the reusable library UI, import the separate HumationEditor product and
+// use `HumationEditorView`.
 
 public struct HumationEditorExample: View {
     @State private var draft: ResolvedHumation?

--- a/Sources/HumationEditor/HumationEditorColor.swift
+++ b/Sources/HumationEditor/HumationEditorColor.swift
@@ -1,0 +1,48 @@
+import Humation
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+#endif
+#if canImport(AppKit)
+import AppKit
+#endif
+
+enum HumationEditorColor {
+    static func color(hex raw: String) -> Color {
+        let normalized = HumationEngine.normalizeHex(raw)
+        if normalized == "transparent" {
+            return .clear
+        }
+
+        guard normalized.count == 6, let value = UInt64(normalized, radix: 16) else {
+            return .gray
+        }
+
+        return Color(
+            red: Double((value >> 16) & 0xFF) / 255,
+            green: Double((value >> 8) & 0xFF) / 255,
+            blue: Double(value & 0xFF) / 255
+        )
+    }
+
+    static var background: Color {
+        #if canImport(UIKit)
+        return Color(uiColor: .systemBackground)
+        #elseif canImport(AppKit)
+        return Color(nsColor: .windowBackgroundColor)
+        #else
+        return Color.clear
+        #endif
+    }
+
+    static var secondaryBackground: Color {
+        #if canImport(UIKit)
+        return Color(uiColor: .secondarySystemBackground)
+        #elseif canImport(AppKit)
+        return Color(nsColor: .controlBackgroundColor)
+        #else
+        return Color.secondary.opacity(0.10)
+        #endif
+    }
+}

--- a/Sources/HumationEditor/HumationEditorConfiguration.swift
+++ b/Sources/HumationEditor/HumationEditorConfiguration.swift
@@ -1,0 +1,133 @@
+import CoreGraphics
+import Humation
+import SwiftUI
+
+/// Configuration for the reusable Humation avatar editor UI.
+public struct HumationEditorConfiguration: Sendable {
+    /// Segmented tab structure.
+    public var tabs: [Tab]
+    /// Hex colour palettes by Humation colour slot.
+    public var colorPalettes: [HumationColorSlot: [String]]
+    /// Selection highlight colour.
+    public var accent: Color
+    /// Cell background. When nil, a platform secondary background is used.
+    public var cellBackground: Color?
+    /// Cell corner radius.
+    public var cornerRadius: CGFloat
+    /// Font provider used by editor labels and controls.
+    public var font: @Sendable (_ size: CGFloat, _ weight: Font.Weight) -> Font
+    /// Whether the background colour slot is shown in the editor.
+    public var showsBackgroundColors: Bool
+
+    public init(
+        tabs: [Tab] = Self.defaultTabs,
+        colorPalettes: [HumationColorSlot: [String]] = Self.defaultColorPalettes,
+        accent: Color = .accentColor,
+        cellBackground: Color? = nil,
+        cornerRadius: CGFloat = 20,
+        font: @escaping @Sendable (_ size: CGFloat, _ weight: Font.Weight) -> Font = {
+            .system(size: $0, weight: $1, design: .rounded)
+        },
+        showsBackgroundColors: Bool = true
+    ) {
+        self.tabs = tabs
+        self.colorPalettes = colorPalettes
+        self.accent = accent
+        self.cellBackground = cellBackground
+        self.cornerRadius = cornerRadius
+        self.font = font
+        self.showsBackgroundColors = showsBackgroundColors
+    }
+
+    public struct Tab: Sendable, Identifiable, Equatable {
+        public var title: String
+        public var slots: [HumationSelectionSlot]
+
+        public var id: String {
+            "\(title):\(slots.map(\.rawValue).joined(separator: ","))"
+        }
+
+        public init(title: String, slots: [HumationSelectionSlot]) {
+            self.title = title
+            self.slots = slots
+        }
+    }
+}
+
+public extension HumationEditorConfiguration {
+    static let defaultTabs: [Tab] = [
+        Tab(title: "Hair", slots: [.head]),
+        Tab(title: "Wear", slots: [.body, .bottom]),
+        Tab(title: "Gear", slots: [.item, .glasses]),
+    ]
+
+    static let defaultColorPalettes: [HumationColorSlot: [String]] = [
+        .background: neutralPalette + osColorScale,
+        .stroke: ["1C1C1E", "3A3A3C", "8E8E93"] + osColorScale,
+        .hair: hairPalette,
+        .skin: skinColorPalette,
+        .clothes: clothesPalette,
+        .bottom: clothesPalette,
+    ]
+
+    private static let osColorScale = [
+        "FF3B30",
+        "FF9500",
+        "FFCC00",
+        "34C759",
+        "00C7BE",
+        "30B0C7",
+        "32ADE6",
+        "007AFF",
+        "5856D6",
+        "AF52DE",
+        "FF2D55",
+    ]
+
+    private static let neutralPalette = [
+        "FFFFFF",
+        "F2F2F7",
+        "E5E5EA",
+        "D1D1D6",
+        "8E8E93",
+        "3A3A3C",
+        "1C1C1E",
+    ]
+
+    private static let hairPalette = [
+        "1C1C1E",
+        "3A3A3C",
+        "8E8E93",
+        "A2845E",
+        "FF3B30",
+        "FF9500",
+        "FFCC00",
+        "34C759",
+        "00C7BE",
+        "32ADE6",
+        "007AFF",
+        "5856D6",
+        "AF52DE",
+        "FF2D55",
+    ]
+
+    private static let skinPalette = [
+        "FFF2E8",
+        "FFD7B5",
+        "F7C08A",
+        "D99A5B",
+        "A96A3A",
+        "7A4A28",
+    ]
+
+    private static let skinColorPalette = [
+        "FFFFFF",
+    ] + skinPalette + [
+        "1C1C1E",
+    ]
+
+    private static let clothesPalette = [
+        "FFFFFF",
+        "1C1C1E",
+    ] + osColorScale
+}

--- a/Sources/HumationEditor/HumationEditorPartCrop.swift
+++ b/Sources/HumationEditor/HumationEditorPartCrop.swift
@@ -1,0 +1,50 @@
+@preconcurrency import CoreGraphics
+import Humation
+
+enum HumationEditorPartCrop {
+    static func crop(
+        for part: HumationManifest.Part,
+        slot: HumationSelectionSlot,
+        in manifest: HumationManifest
+    ) -> HumationManifest.ViewBox? {
+        guard let bounds = HumationRenderer.contentBounds(of: part, in: manifest) else {
+            return nil
+        }
+
+        switch slot {
+        case .head:
+            return manifest.avatarCrop
+        case .body:
+            return HumationManifest.ViewBox(x: -18, y: 35, width: 116, height: 116)
+        case .bottom:
+            return HumationManifest.ViewBox(x: -18, y: 69, width: 116, height: 116)
+        case .item:
+            return scaledCrop(bounds: bounds, minimumSide: 108, scale: 1.42)
+        case .glasses:
+            return scaledCrop(bounds: bounds, minimumSide: 126, scale: 1.82)
+        }
+    }
+
+    static func previewSize(for slot: HumationSelectionSlot) -> CGFloat {
+        switch slot {
+        case .item:
+            return 98
+        default:
+            return 88
+        }
+    }
+
+    private static func scaledCrop(
+        bounds: CGRect,
+        minimumSide: CGFloat,
+        scale: CGFloat
+    ) -> HumationManifest.ViewBox {
+        let side = max(max(bounds.width, bounds.height) * scale, minimumSide)
+        return HumationManifest.ViewBox(
+            x: Double(bounds.midX - side / 2),
+            y: Double(bounds.midY - side / 2),
+            width: Double(side),
+            height: Double(side)
+        )
+    }
+}

--- a/Sources/HumationEditor/HumationEditorRenderView.swift
+++ b/Sources/HumationEditor/HumationEditorRenderView.swift
@@ -1,0 +1,112 @@
+@preconcurrency import CoreGraphics
+import Foundation
+import Humation
+import SwiftUI
+
+struct HumationEditorRenderView: View {
+    @Environment(\.displayScale) private var displayScale
+    @State private var rendered: (key: String, image: CGImage)?
+
+    let resolved: ResolvedHumation
+    let manifest: HumationManifest
+    let size: CGFloat
+    var crop: HumationManifest.ViewBox?
+
+    var body: some View {
+        Group {
+            if let image = displayImage {
+                Image(decorative: image, scale: displayScale)
+                    .resizable()
+                    .interpolation(.high)
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                Rectangle()
+                    .fill(skeletonColor)
+            }
+        }
+        .frame(width: size, height: size)
+        .clipped()
+        .task(id: renderKey) {
+            await loadImage()
+        }
+    }
+
+    private var pixels: Int {
+        let target = Int((size * displayScale).rounded(.up))
+        return [32, 64, 128, 256, 512].first { $0 >= target } ?? 512
+    }
+
+    private var renderKey: String {
+        let cropKey = crop.map { "\($0.x)_\($0.y)_\($0.width)_\($0.height)" } ?? "avatar"
+        return "humation-editor:\(resolved.cacheToken)@\(pixels)#\(cropKey)"
+    }
+
+    private var displayImage: CGImage? {
+        let key = renderKey
+        if let rendered, rendered.key == key {
+            return rendered.image
+        }
+        return HumationEditorRenderCache.shared.image(forKey: key)
+    }
+
+    private var skeletonColor: Color {
+        if resolved.background != "transparent" {
+            return HumationEditorColor.color(hex: resolved.background)
+        }
+        return .clear
+    }
+
+    private func loadImage() async {
+        let key = renderKey
+        if let image = HumationEditorRenderCache.shared.image(forKey: key) {
+            rendered = (key, image)
+            return
+        }
+
+        let resolved = resolved
+        let manifest = manifest
+        let pixels = pixels
+        let crop = crop
+        let image: CGImage? = await Task.detached(priority: .userInitiated) { () -> CGImage? in
+            if let image = HumationEditorRenderCache.shared.image(forKey: key) {
+                return image
+            }
+
+            guard let image = HumationRenderer.render(
+                resolved: resolved,
+                manifest: manifest,
+                pixels: pixels,
+                crop: crop
+            ) else {
+                return nil
+            }
+
+            HumationEditorRenderCache.shared.set(image, forKey: key, cost: pixels * pixels * 4)
+            return image
+        }.value
+
+        if !Task.isCancelled, let image {
+            rendered = (key, image)
+        }
+    }
+}
+
+final class HumationEditorRenderCache: @unchecked Sendable {
+    static let shared = HumationEditorRenderCache()
+
+    private let cache: NSCache<NSString, CGImage>
+
+    private init() {
+        let cache = NSCache<NSString, CGImage>()
+        cache.totalCostLimit = 24 * 1024 * 1024
+        self.cache = cache
+    }
+
+    func image(forKey key: String) -> CGImage? {
+        cache.object(forKey: key as NSString)
+    }
+
+    func set(_ image: CGImage, forKey key: String, cost: Int) {
+        cache.setObject(image, forKey: key as NSString, cost: cost)
+    }
+}

--- a/Sources/HumationEditor/HumationEditorView.swift
+++ b/Sources/HumationEditor/HumationEditorView.swift
@@ -1,0 +1,437 @@
+import Humation
+import SwiftUI
+
+public struct HumationEditorView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Binding private var profile: HumationProfile
+    @State private var draft: ResolvedHumation?
+    @State private var selectedTabID: String
+
+    private let seed: String?
+    private let configuration: HumationEditorConfiguration
+
+    private static let previewSize: CGFloat = 132
+    private static let tabBarHeight: CGFloat = 58
+    private static let horizontalInset: CGFloat = 16
+    private static let partCellHeight: CGFloat = 100
+    private static let partGridGap: CGFloat = 6
+    private static let scrollTopID = "humation-editor-scroll-top"
+
+    private var columns: [GridItem] {
+        Array(
+            repeating: GridItem(.flexible(minimum: 76), spacing: Self.partGridGap),
+            count: 3
+        )
+    }
+
+    public init(
+        profile: Binding<HumationProfile>,
+        seed: String? = nil,
+        configuration: HumationEditorConfiguration = .init()
+    ) {
+        _profile = profile
+        self.seed = seed
+        self.configuration = configuration
+        _selectedTabID = State(initialValue: configuration.tabs.first?.id ?? "")
+    }
+
+    public var body: some View {
+        Group {
+            if let manifest = Humation.manifest {
+                content(manifest: manifest, draft: currentDraft(in: manifest))
+            } else {
+                Text("Humation assets unavailable")
+                    .font(configuration.font(15, .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .background(HumationEditorColor.background)
+        .onAppear {
+            initializeDraftIfNeeded()
+        }
+    }
+
+    private func content(manifest: HumationManifest, draft: ResolvedHumation) -> some View {
+        VStack(spacing: 0) {
+            previewHeader(manifest: manifest, draft: draft)
+
+            if configuration.tabs.count > 1 {
+                tabBar
+            }
+
+            partsPanel(manifest: manifest, draft: draft)
+                .layoutPriority(1)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var tabBar: some View {
+        Picker("Parts", selection: $selectedTabID) {
+            ForEach(configuration.tabs) { tab in
+                Text(tab.title)
+                    .font(configuration.font(15, .semibold))
+                    .tag(tab.id)
+            }
+        }
+        .pickerStyle(.segmented)
+        .font(configuration.font(15, .semibold))
+        .padding(.horizontal, 12)
+        .padding(.bottom, 4)
+        .frame(maxWidth: .infinity)
+        .frame(height: Self.tabBarHeight, alignment: .top)
+    }
+
+    private func previewHeader(manifest: HumationManifest, draft: ResolvedHumation) -> some View {
+        VStack(spacing: 12) {
+            HumationAvatarView(resolved: draft, size: Self.previewSize)
+                .clipShape(Circle())
+                .background(HumationEditorColor.color(hex: draft.background), in: Circle())
+                .overlay(Circle().strokeBorder(Color.primary.opacity(0.10), lineWidth: 1))
+
+            Button {
+                randomize(manifest: manifest)
+            } label: {
+                Label("Randomize", systemImage: "arrow.triangle.2.circlepath")
+                    .font(configuration.font(15, .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.82)
+            }
+            .buttonStyle(.bordered)
+            .tint(configuration.accent)
+        }
+        .padding(.top, 12)
+        .padding(.horizontal, 20)
+        .padding(.bottom, 14)
+    }
+
+    private func partsPanel(manifest: HumationManifest, draft: ResolvedHumation) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                Color.clear
+                    .frame(height: 0)
+                    .id(Self.scrollTopID)
+
+                if !globalColorSlots.isEmpty {
+                    colorSection(title: "Colors", colorSlots: globalColorSlots, draft: draft, manifest: manifest)
+                        .padding(.bottom, 18)
+                }
+
+                if let tab = selectedTab {
+                    VStack(alignment: .leading, spacing: 22) {
+                        ForEach(tab.slots, id: \.self) { slot in
+                            slotSection(slot: slot, draft: draft, manifest: manifest)
+                        }
+                    }
+                }
+            }
+            .onChange(of: selectedTabID) { _ in
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    proxy.scrollTo(Self.scrollTopID, anchor: .top)
+                }
+            }
+        }
+    }
+
+    private func slotSection(
+        slot: HumationSelectionSlot,
+        draft: ResolvedHumation,
+        manifest: HumationManifest
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            let colorSlots = colorSlots(for: slot)
+            if !colorSlots.isEmpty {
+                colorRows(colorSlots: colorSlots, draft: draft, manifest: manifest)
+                    .padding(.bottom, 2)
+            }
+
+            Text(slotTitle(slot))
+                .font(configuration.font(14, .heavy))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, Self.horizontalInset)
+
+            LazyVGrid(columns: columns, spacing: Self.partGridGap) {
+                ForEach(manifest.parts(in: slot), id: \.id) { part in
+                    partCell(part: part, slot: slot, draft: draft, manifest: manifest)
+                }
+            }
+            .padding(.horizontal, Self.horizontalInset)
+        }
+    }
+
+    private func partCell(
+        part: HumationManifest.Part,
+        slot: HumationSelectionSlot,
+        draft: ResolvedHumation,
+        manifest: HumationManifest
+    ) -> some View {
+        let variant = partPreviewVariant(part: part, slot: slot, draft: draft)
+        let crop = HumationEditorPartCrop.crop(for: part, slot: slot, in: manifest)
+        let isSelected = draft.selections[slot] == part.id
+
+        return Button {
+            select(part: part, slot: slot, manifest: manifest)
+        } label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: configuration.cornerRadius, style: .continuous)
+                    .fill(cellBackground)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: configuration.cornerRadius, style: .continuous)
+                            .strokeBorder(
+                                isSelected ? configuration.accent : Color.clear,
+                                lineWidth: 3
+                            )
+                    }
+
+                if let crop {
+                    HumationEditorRenderView(
+                        resolved: variant,
+                        manifest: manifest,
+                        size: HumationEditorPartCrop.previewSize(for: slot),
+                        crop: crop
+                    )
+                } else {
+                    Image(systemName: "slash.circle")
+                        .font(configuration.font(25, .bold))
+                        .foregroundStyle(Color.secondary.opacity(0.7))
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: Self.partCellHeight)
+            .contentShape(
+                RoundedRectangle(cornerRadius: configuration.cornerRadius, style: .continuous)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(part.name ?? part.id)
+        .accessibilityValue(isSelected ? "Selected" : "")
+    }
+
+    private func colorSection(
+        title: String,
+        colorSlots: [HumationColorSlot],
+        draft: ResolvedHumation,
+        manifest: HumationManifest
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(configuration.font(14, .heavy))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, Self.horizontalInset)
+
+            colorRows(colorSlots: colorSlots, draft: draft, manifest: manifest)
+        }
+    }
+
+    private func colorRows(
+        colorSlots: [HumationColorSlot],
+        draft: ResolvedHumation,
+        manifest: HumationManifest
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            ForEach(colorSlots, id: \.self) { colorSlot in
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(colorTitle(colorSlot))
+                        .font(configuration.font(13, .heavy))
+                        .foregroundStyle(Color.secondary)
+                        .padding(.horizontal, Self.horizontalInset)
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        LazyHStack(spacing: 9) {
+                            ForEach(configuration.colorPalettes[colorSlot] ?? [], id: \.self) { hex in
+                                colorDot(
+                                    colorSlot: colorSlot,
+                                    hex: hex,
+                                    draft: draft,
+                                    manifest: manifest
+                                )
+                            }
+                        }
+                        .padding(.horizontal, Self.horizontalInset)
+                        .padding(.vertical, 4)
+                    }
+                }
+            }
+        }
+    }
+
+    private func colorDot(
+        colorSlot: HumationColorSlot,
+        hex: String,
+        draft: ResolvedHumation,
+        manifest: HumationManifest
+    ) -> some View {
+        let normalized = HumationEngine.normalizeHex(hex)
+        let current = draft.hex(for: colorSlot)
+        let isSelected = current?.caseInsensitiveCompare(normalized) == .orderedSame
+
+        return Button {
+            select(colorSlot: colorSlot, hex: normalized, manifest: manifest)
+        } label: {
+            Circle()
+                .fill(HumationEditorColor.color(hex: normalized))
+                .frame(width: 40, height: 40)
+                .overlay(Circle().strokeBorder(colorChipBorder, lineWidth: 1.5))
+                .padding(6)
+                .overlay(
+                    Circle().strokeBorder(
+                        isSelected ? configuration.accent : Color.clear,
+                        lineWidth: 3
+                    )
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(colorTitle(colorSlot))
+        .accessibilityValue(isSelected ? "Selected" : "")
+    }
+
+    private var selectedTab: HumationEditorConfiguration.Tab? {
+        if let exact = configuration.tabs.first(where: { $0.id == selectedTabID }) {
+            return exact
+        }
+        return configuration.tabs.first
+    }
+
+    private var globalColorSlots: [HumationColorSlot] {
+        var slots: [HumationColorSlot] = [.stroke]
+        if configuration.showsBackgroundColors {
+            slots.insert(.background, at: 0)
+        }
+        return slots.filter { !(configuration.colorPalettes[$0] ?? []).isEmpty }
+    }
+
+    private var cellBackground: Color {
+        configuration.cellBackground ?? HumationEditorColor.secondaryBackground
+    }
+
+    private var colorChipBorder: Color {
+        colorScheme == .dark ? Color.white.opacity(0.30) : Color.black.opacity(0.22)
+    }
+
+    private func colorSlots(for slot: HumationSelectionSlot) -> [HumationColorSlot] {
+        let slots: [HumationColorSlot]
+        switch slot {
+        case .head:
+            slots = [.hair]
+        case .body:
+            slots = [.clothes, .skin]
+        case .bottom:
+            slots = [.bottom]
+        case .item, .glasses:
+            slots = []
+        }
+        return slots.filter { !(configuration.colorPalettes[$0] ?? []).isEmpty }
+    }
+
+    private func partPreviewVariant(
+        part: HumationManifest.Part,
+        slot: HumationSelectionSlot,
+        draft: ResolvedHumation
+    ) -> ResolvedHumation {
+        var variant = draft
+        variant.selections = [slot: part.id]
+        variant.background = "transparent"
+        return variant
+    }
+
+    private func select(
+        part: HumationManifest.Part,
+        slot: HumationSelectionSlot,
+        manifest: HumationManifest
+    ) {
+        var updated = currentDraft(in: manifest)
+        updated.selections[slot] = part.id
+        draft = updated
+        commit(updated)
+    }
+
+    private func select(
+        colorSlot: HumationColorSlot,
+        hex: String,
+        manifest: HumationManifest
+    ) {
+        var updated = currentDraft(in: manifest)
+        if colorSlot == .background {
+            updated.background = HumationEngine.normalizeHex(hex)
+        } else {
+            updated.colors[colorSlot] = HumationEngine.normalizeHex(hex)
+        }
+        draft = updated
+        commit(updated)
+    }
+
+    private func randomize(manifest: HumationManifest) {
+        var updated = currentDraft(in: manifest)
+
+        for slot in HumationSelectionSlot.allCases {
+            if let pick = manifest.parts(in: slot).randomElement() {
+                updated.selections[slot] = pick.id
+            }
+        }
+
+        for colorSlot in HumationColorSlot.allCases {
+            guard let hex = configuration.colorPalettes[colorSlot]?.randomElement() else {
+                continue
+            }
+            let normalized = HumationEngine.normalizeHex(hex)
+            if colorSlot == .background {
+                updated.background = normalized
+            } else {
+                updated.colors[colorSlot] = normalized
+            }
+        }
+
+        draft = updated
+        commit(updated)
+    }
+
+    private func initializeDraftIfNeeded() {
+        guard draft == nil, let manifest = Humation.manifest else {
+            return
+        }
+        let resolved = profile.resolved(against: manifest, seed: seed)
+        draft = resolved
+    }
+
+    private func currentDraft(in manifest: HumationManifest) -> ResolvedHumation {
+        draft ?? profile.resolved(against: manifest, seed: seed)
+    }
+
+    private func commit(_ resolved: ResolvedHumation) {
+        profile = HumationProfile(resolved: resolved)
+    }
+
+    private func colorTitle(_ slot: HumationColorSlot) -> String {
+        switch slot {
+        case .background:
+            return "Background"
+        case .stroke:
+            return "Line"
+        case .hair:
+            return "Hair"
+        case .skin:
+            return "Skin"
+        case .clothes:
+            return "Wear"
+        case .bottom:
+            return "Bottom"
+        }
+    }
+
+    private func slotTitle(_ slot: HumationSelectionSlot) -> String {
+        switch slot {
+        case .head:
+            return "Head"
+        case .body:
+            return "Body"
+        case .bottom:
+            return "Bottom"
+        case .item:
+            return "Item"
+        case .glasses:
+            return "Glasses"
+        }
+    }
+}

--- a/Tests/HumationEditorTests/HumationEditorTests.swift
+++ b/Tests/HumationEditorTests/HumationEditorTests.swift
@@ -1,0 +1,114 @@
+import CoreGraphics
+import SwiftUI
+import XCTest
+
+import Humation
+@testable import HumationEditor
+
+final class HumationEditorTests: XCTestCase {
+    func testDefaultConfiguration() {
+        let configuration = HumationEditorConfiguration()
+
+        XCTAssertEqual(configuration.tabs.count, 3)
+        XCTAssertEqual(configuration.tabs[0].title, "Hair")
+        XCTAssertEqual(configuration.tabs[0].slots, [.head])
+        XCTAssertEqual(configuration.tabs[1].title, "Wear")
+        XCTAssertEqual(configuration.tabs[1].slots, [.body, .bottom])
+        XCTAssertEqual(configuration.tabs[2].title, "Gear")
+        XCTAssertEqual(configuration.tabs[2].slots, [.item, .glasses])
+        XCTAssertNil(configuration.cellBackground)
+        XCTAssertEqual(configuration.cornerRadius, 20)
+        XCTAssertTrue(configuration.showsBackgroundColors)
+
+        XCTAssertFalse(configuration.colorPalettes.isEmpty)
+        for slot in HumationColorSlot.allCases {
+            XCTAssertFalse(
+                configuration.colorPalettes[slot, default: []].isEmpty,
+                "\(slot.rawValue) palette should not be empty"
+            )
+        }
+    }
+
+    func testPartCropForEachSlot() throws {
+        let manifest = try XCTUnwrap(Humation.manifest)
+
+        let head = try XCTUnwrap(manifest.parts(in: .head).first)
+        XCTAssertEqual(
+            HumationEditorPartCrop.crop(for: head, slot: .head, in: manifest),
+            manifest.avatarCrop
+        )
+
+        let body = try XCTUnwrap(manifest.parts(in: .body).first)
+        XCTAssertEqual(
+            HumationEditorPartCrop.crop(for: body, slot: .body, in: manifest),
+            HumationManifest.ViewBox(x: -18, y: 35, width: 116, height: 116)
+        )
+
+        let bottom = try XCTUnwrap(manifest.parts(in: .bottom).first)
+        XCTAssertEqual(
+            HumationEditorPartCrop.crop(for: bottom, slot: .bottom, in: manifest),
+            HumationManifest.ViewBox(x: -18, y: 69, width: 116, height: 116)
+        )
+
+        let item = try XCTUnwrap(
+            manifest.parts(in: .item).first {
+                HumationRenderer.contentBounds(of: $0, in: manifest) != nil
+            }
+        )
+        let itemBounds = try XCTUnwrap(HumationRenderer.contentBounds(of: item, in: manifest))
+        assertViewBox(
+            HumationEditorPartCrop.crop(for: item, slot: .item, in: manifest),
+            equalsScaledCrop: scaledCrop(bounds: itemBounds, minimumSide: 108, scale: 1.42)
+        )
+
+        let glasses = try XCTUnwrap(
+            manifest.parts(in: .glasses).first {
+                HumationRenderer.contentBounds(of: $0, in: manifest) != nil
+            }
+        )
+        let glassesBounds = try XCTUnwrap(HumationRenderer.contentBounds(of: glasses, in: manifest))
+        assertViewBox(
+            HumationEditorPartCrop.crop(for: glasses, slot: .glasses, in: manifest),
+            equalsScaledCrop: scaledCrop(bounds: glassesBounds, minimumSide: 126, scale: 1.82)
+        )
+    }
+
+    @MainActor
+    func testHumationEditorViewCanInitialize() {
+        _ = HumationEditorView(
+            profile: .constant(HumationProfile()),
+            seed: "editor-test",
+            configuration: .init()
+        )
+    }
+
+    private func assertViewBox(
+        _ actual: HumationManifest.ViewBox?,
+        equalsScaledCrop expected: HumationManifest.ViewBox,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let actual else {
+            XCTFail("Expected crop", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(actual.x, expected.x, accuracy: 0.0001, file: file, line: line)
+        XCTAssertEqual(actual.y, expected.y, accuracy: 0.0001, file: file, line: line)
+        XCTAssertEqual(actual.width, expected.width, accuracy: 0.0001, file: file, line: line)
+        XCTAssertEqual(actual.height, expected.height, accuracy: 0.0001, file: file, line: line)
+    }
+
+    private func scaledCrop(
+        bounds: CGRect,
+        minimumSide: CGFloat,
+        scale: CGFloat
+    ) -> HumationManifest.ViewBox {
+        let side = max(max(bounds.width, bounds.height) * scale, minimumSide)
+        return HumationManifest.ViewBox(
+            x: Double(bounds.midX - side / 2),
+            y: Double(bounds.midY - side / 2),
+            width: Double(side),
+            height: Double(side)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Adds a second library product, **`HumationEditor`**, so apps get a ready-made "build your avatar" screen instead of reimplementing one on top of the core APIs.

- **`HumationEditorView(profile: Binding<HumationProfile>, seed:, configuration:)`** — live preview, slot tabs, per-slot color palette rows, 3-column part grid with per-slot thumbnail crop calibration, and a randomize action. Selections write straight to the profile binding; the host app decides save/discard semantics (e.g. wrap in a modal).
- **`HumationEditorConfiguration`** — tab layout, per-slot color palettes (sensible defaults included), and theming hooks: accent color, cell background, corner radius, and a font provider closure so apps can inject a custom typeface.
- Async thumbnail rendering backed by a 24 MB `NSCache`, keyed by `cacheToken` + pixels + crop.
- Extracted and generalized from a production avatar builder (DopaDopa, ~580 lines) — the app now only needs a thin themed wrapper.

**Base branch note:** depends on `HumationProfile` from #2, so this PR targets `feat/humation-profile`; it will retarget to `main` automatically once #2 merges.

## Test plan
- `swift test` — 17 tests pass across both targets (new: configuration defaults cover every color slot, per-slot crop calculation, view construction with a constant binding)
- Verified `swift build` for macOS; the target uses no UIKit-only APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)