### PR TITLE
feat: random avatars, avatar-view convenience inits, and slot metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- Add random avatars: `HumationProfile.random(in:using:)` / `random(in:)` and the
+  `Humation.randomProfile()` facade (pass a `RandomNumberGenerator` for
+  reproducible results).
+- Add `HumationAvatarView(seed:size:)` and `HumationAvatarView(profile:seed:size:)`
+  convenience initialisers that resolve against the bundled manifest.
+- Add slot metadata: `displayName` on `HumationSelectionSlot` / `HumationColorSlot`
+  and `defaultSwatches` on `HumationColorSlot` for building pickers.
+
 ## 1.1.0 - 2026-07-05
 
 - Add `HumationProfile`: a serialisable avatar wire format with profile healing

--- a/README.md
+++ b/README.md
@@ -61,9 +61,13 @@ Humation.prewarm()
 let image  = Humation.image(seed: user.id, pixels: 256)     // UIImage?
 let cg     = Humation.cgImage(seed: user.id, pixels: 256)   // CGImage?
 
-// SwiftUI
-if let resolved = Humation.resolved(seed: user.id) {
-    HumationAvatarView(resolved: resolved, size: 96)
+// SwiftUI — resolves against the bundled manifest for you
+HumationAvatarView(seed: user.id, size: 96)
+HumationAvatarView(profile: profile, seed: user.id, size: 96)
+
+// "Surprise me" — a random avatar
+if let random = Humation.randomProfile() {
+    let image = Humation.image(profile: random, pixels: 256)
 }
 ```
 
@@ -144,15 +148,15 @@ pull in `HumationEditor` if you use it.
 
 | Type | Role |
 |---|---|
-| `Humation` | Facade: `prewarm()`, `manifest`, seed **or profile** → `image` / `cgImage` / `nsImage` / `resolved` |
-| `HumationProfile` | `Codable` / `Sendable` avatar wire format (selections + colours) with healing on resolve |
+| `Humation` | Facade: `prewarm()`, `manifest`, `randomProfile()`, seed **or profile** → `image` / `cgImage` / `nsImage` / `resolved` |
+| `HumationProfile` | `Codable` / `Sendable` avatar wire format (selections + colours) with healing on resolve; `random(in:using:)` |
 | `HumationManifest` / `HumationManifestStore` | Asset manifest model + bundled `humation-1` loader |
 | `HumationTraits` → `ResolvedHumation` | Input design (seed + overrides) resolved to concrete parts + colours |
 | `HumationRenderer` | `render` / `pngData` → `CGImage` / `Data` (`shape: .square` \| `.circle`), `image` / `nsImage`, `contentBounds(of:in:)` |
-| `HumationAvatarView` | SwiftUI view — cached bitmap, cross-platform |
+| `HumationAvatarView` | SwiftUI view — cached bitmap, cross-platform; `init(seed:…)` / `init(profile:…)` convenience |
 | `HumationEditorView` | Avatar builder UI (in the optional `HumationEditor` product) |
 | `HumationValidator` | Lint a custom pack against the supported SVG subset |
-| `HumationSelectionSlot` / `HumationColorSlot` | The 5 part slots / 6 colour slots |
+| `HumationSelectionSlot` / `HumationColorSlot` | The 5 part slots / 6 colour slots; `displayName`, and `defaultSwatches` for colours |
 
 ## SVG subset
 

--- a/Sources/Humation/Model/HumationRandom.swift
+++ b/Sources/Humation/Model/HumationRandom.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+// MARK: - Random avatars
+//
+// A random avatar picks a random part per selection slot (from the manifest) and
+// a random colour per slot (from `HumationColorSlot.defaultSwatches`). Passing an
+// explicit `RandomNumberGenerator` makes the result reproducible — handy for
+// tests, previews, or seeded "shuffle" experiences.
+
+extension HumationProfile {
+    /// A random profile resolved against `manifest`, drawing randomness from
+    /// `generator`. Every selection slot with available parts gets a random pick;
+    /// every colour slot gets a random swatch.
+    public static func random(
+        in manifest: HumationManifest,
+        using generator: inout some RandomNumberGenerator
+    ) -> HumationProfile {
+        var selections: [HumationSelectionSlot: String] = [:]
+        for slot in HumationSelectionSlot.allCases {
+            if let pick = manifest.parts(in: slot).randomElement(using: &generator) {
+                selections[slot] = pick.id
+            }
+        }
+
+        var colors: [HumationColorSlot: String] = [:]
+        for slot in HumationColorSlot.allCases {
+            if let hex = slot.defaultSwatches.randomElement(using: &generator) {
+                colors[slot] = hex
+            }
+        }
+
+        return HumationProfile(selections: selections, colors: colors)
+    }
+
+    /// A random profile using the system random number generator.
+    public static func random(in manifest: HumationManifest) -> HumationProfile {
+        var generator = SystemRandomNumberGenerator()
+        return random(in: manifest, using: &generator)
+    }
+}
+
+extension Humation {
+    /// A random profile using the bundled manifest, or `nil` if the manifest is
+    /// unavailable. Pair with `image(profile:pixels:)` for a one-line "surprise
+    /// me" avatar.
+    public static func randomProfile() -> HumationProfile? {
+        guard let manifest = HumationManifestStore.shared else { return nil }
+        return HumationProfile.random(in: manifest)
+    }
+
+    /// A random profile using the bundled manifest and an explicit generator
+    /// (reproducible), or `nil` if the manifest is unavailable.
+    public static func randomProfile(
+        using generator: inout some RandomNumberGenerator
+    ) -> HumationProfile? {
+        guard let manifest = HumationManifestStore.shared else { return nil }
+        return HumationProfile.random(in: manifest, using: &generator)
+    }
+}

--- a/Sources/Humation/Model/HumationSlotMetadata.swift
+++ b/Sources/Humation/Model/HumationSlotMetadata.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+// MARK: - Slot display metadata
+//
+// Human-readable titles and curated colour swatches for the avatar slots. These
+// let callers build their own picker / editor UI (tabs, swatch grids) without
+// hand-maintaining parallel tables, and back the randomisation API.
+
+extension HumationSelectionSlot {
+    /// Human-readable title for UI, e.g. a slot tab label.
+    public var displayName: String {
+        switch self {
+        case .head: return "Head"
+        case .body: return "Body"
+        case .bottom: return "Bottom"
+        case .item: return "Item"
+        case .glasses: return "Glasses"
+        }
+    }
+}
+
+extension HumationColorSlot {
+    /// Human-readable title for UI, e.g. a colour-slot label.
+    public var displayName: String {
+        switch self {
+        case .background: return "Background"
+        case .stroke: return "Outline"
+        case .hair: return "Hair"
+        case .skin: return "Skin"
+        case .clothes: return "Clothes"
+        case .bottom: return "Bottom"
+        }
+    }
+
+    /// A curated set of sensible swatches for this colour slot — suitable for a
+    /// colour picker or for randomising an avatar. Values are 6-char uppercase
+    /// hex without a leading `#`.
+    public var defaultSwatches: [String] {
+        switch self {
+        case .background:
+            return ["FFFFFF", "F2F2F7", "E5E5EA", "D1D1D6", "FFD8A8", "D0EBFF", "E7F5D0", "FFE3E3"]
+        case .stroke:
+            return ["1C1C1E", "3A3A3C", "8E8E93"]
+        case .hair:
+            return ["1C1C1E", "3A3A3C", "8E8E93", "A2845E", "6B4423", "C9A227", "FF9500", "AF52DE"]
+        case .skin:
+            return ["FFE0BD", "F1C27D", "E0AC69", "C68642", "8D5524", "FFDFC4", "F0D5B1"]
+        case .clothes, .bottom:
+            return [
+                "FF3B30", "FF9500", "FFCC00", "34C759", "00C7BE", "32ADE6",
+                "007AFF", "5856D6", "AF52DE", "FF2D55", "1C1C1E", "FFFFFF",
+            ]
+        }
+    }
+}

--- a/Sources/Humation/Views/HumationAvatarView+Convenience.swift
+++ b/Sources/Humation/Views/HumationAvatarView+Convenience.swift
@@ -1,0 +1,35 @@
+import CoreGraphics
+import SwiftUI
+
+// MARK: - Ergonomic initialisers
+//
+// Convenience inits that resolve against the bundled manifest so callers don't
+// have to thread `Humation.resolved(...)` through every call site. If the bundled
+// manifest is somehow unavailable, they fall back to an empty design (renders the
+// skeleton) rather than failing — the manifest loads synchronously on first
+// access, so this only bites if the bundle resource is missing.
+
+extension HumationAvatarView {
+    /// Render the avatar for a `seed`, resolved against the bundled manifest.
+    public init(seed: String, size: CGFloat, crop: HumationManifest.ViewBox? = nil) {
+        let resolved = Humation.resolved(seed: seed) ?? .empty
+        self.init(resolved: resolved, size: size, crop: crop)
+    }
+
+    /// Render a `profile`, resolved against the bundled manifest, with `seed`
+    /// completing any slots the profile leaves unset.
+    public init(
+        profile: HumationProfile,
+        seed: String? = nil,
+        size: CGFloat,
+        crop: HumationManifest.ViewBox? = nil
+    ) {
+        let resolved = Humation.resolved(profile: profile, seed: seed) ?? .empty
+        self.init(resolved: resolved, size: size, crop: crop)
+    }
+}
+
+extension ResolvedHumation {
+    /// Empty design used as a graceful fallback when the manifest is unavailable.
+    static let empty = ResolvedHumation(selections: [:], colors: [:], background: "transparent")
+}

--- a/Tests/HumationTests/HumationRandomTests.swift
+++ b/Tests/HumationTests/HumationRandomTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+
+@testable import Humation
+
+final class HumationRandomTests: XCTestCase {
+
+    /// Deterministic generator so random tests are reproducible (SplitMix64).
+    private struct SeededGenerator: RandomNumberGenerator {
+        var state: UInt64
+        init(seed: UInt64) { state = seed }
+        mutating func next() -> UInt64 {
+            state = state &+ 0x9E37_79B9_7F4A_7C15
+            var z = state
+            z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+            z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+            return z ^ (z >> 31)
+        }
+    }
+
+    private func manifest() throws -> HumationManifest {
+        try XCTUnwrap(HumationManifestStore.shared, "bundled manifest should load")
+    }
+
+    // MARK: random(in:using:)
+
+    func testRandomIsReproducibleWithSeededGenerator() throws {
+        let manifest = try manifest()
+        var a = SeededGenerator(seed: 42)
+        var b = SeededGenerator(seed: 42)
+        XCTAssertEqual(
+            HumationProfile.random(in: manifest, using: &a),
+            HumationProfile.random(in: manifest, using: &b)
+        )
+    }
+
+    func testDifferentSeedsGiveDifferentProfiles() throws {
+        let manifest = try manifest()
+        var a = SeededGenerator(seed: 1)
+        var b = SeededGenerator(seed: 99)
+        XCTAssertNotEqual(
+            HumationProfile.random(in: manifest, using: &a),
+            HumationProfile.random(in: manifest, using: &b)
+        )
+    }
+
+    func testRandomSelectionsAreValidPartsInTheRightSlot() throws {
+        let manifest = try manifest()
+        var gen = SeededGenerator(seed: 7)
+        let profile = HumationProfile.random(in: manifest, using: &gen)
+        for (slot, partId) in profile.selections {
+            let part = try XCTUnwrap(manifest.part(id: partId), "\(partId) should exist")
+            XCTAssertEqual(part.selectionSlot, slot.rawValue)
+        }
+    }
+
+    func testRandomColorsComeFromDefaultSwatches() throws {
+        let manifest = try manifest()
+        var gen = SeededGenerator(seed: 3)
+        let profile = HumationProfile.random(in: manifest, using: &gen)
+        for (slot, hex) in profile.colors {
+            XCTAssertTrue(
+                slot.defaultSwatches.contains(hex),
+                "\(hex) not in \(slot) swatches"
+            )
+        }
+    }
+
+    func testRandomProfileResolvesAndRenders() throws {
+        let manifest = try manifest()
+        var gen = SeededGenerator(seed: 5)
+        let resolved = HumationProfile.random(in: manifest, using: &gen).resolved(against: manifest)
+        let image = HumationRenderer.render(resolved: resolved, manifest: manifest, pixels: 64)
+        XCTAssertNotNil(image)
+    }
+
+    func testFacadeRandomProfile() {
+        XCTAssertNotNil(Humation.randomProfile())
+        var gen = SeededGenerator(seed: 11)
+        XCTAssertNotNil(Humation.randomProfile(using: &gen))
+    }
+
+    // MARK: slot metadata
+
+    func testDefaultSwatchesAreNormalizedHex() {
+        for slot in HumationColorSlot.allCases {
+            let swatches = slot.defaultSwatches
+            XCTAssertFalse(swatches.isEmpty, "\(slot) has no swatches")
+            for hex in swatches {
+                XCTAssertEqual(hex, HumationEngine.normalizeHex(hex), "\(hex) not normalized")
+                XCTAssertEqual(hex.count, 6, "\(hex) is not 6-char hex")
+            }
+        }
+    }
+
+    func testDisplayNamesArePresent() {
+        for slot in HumationSelectionSlot.allCases {
+            XCTAssertFalse(slot.displayName.isEmpty)
+        }
+        for slot in HumationColorSlot.allCases {
+            XCTAssertFalse(slot.displayName.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## What

Three additive, backward-compatible improvements to the core `Humation` product, driven by gaps we hit consuming the library (we had to hand-roll palettes/randomisation/persistence on the app side).

### 1. Random avatars
- `HumationProfile.random(in:using:)` and `random(in:)` — a random part per selection slot + a random colour per slot.
- `Humation.randomProfile()` facade using the bundled manifest.
- Both accept an explicit `RandomNumberGenerator`, so results are **reproducible** (tests, previews, seeded shuffles).

### 2. `HumationAvatarView` convenience inits
- `HumationAvatarView(seed:size:crop:)` and `HumationAvatarView(profile:seed:size:crop:)` resolve against the bundled manifest, so callers no longer thread `Humation.resolved(...)` through every call site. Graceful empty-design fallback if the manifest is unavailable.

### 3. Slot metadata
- `displayName` on `HumationSelectionSlot` / `HumationColorSlot`.
- `defaultSwatches` on `HumationColorSlot` — a curated per-slot palette for building pickers and for randomisation.

## Tests
`HumationRandomTests`: determinism with a seeded generator, selections point to valid parts in the right slot, colours come from the slot swatches, a random profile resolves + renders, facade works, swatches are normalized 6-char hex, display names present. `swift build` + `swift test` green locally.

## Notes
- Purely additive — no changes to existing signatures or rendering output.
- `HumationEditor` still carries its own `defaultColorPalettes`; a follow-up could repoint it at `HumationColorSlot.defaultSwatches` to de-duplicate. Left out here to keep the diff focused.