### PR TITLE
feat: Transferable avatars + pngData convenience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.2.0 - 2026-07-05
 
 - Add random avatars: `HumationProfile.random(in:using:)` / `random(in:)` and the
   `Humation.randomProfile()` facade (pass a `RandomNumberGenerator` for
@@ -9,6 +9,10 @@
   convenience initialisers that resolve against the bundled manifest.
 - Add slot metadata: `displayName` on `HumationSelectionSlot` / `HumationColorSlot`
   and `defaultSwatches` on `HumationColorSlot` for building pickers.
+- Add avatar sharing: `ResolvedHumation` conforms to `Transferable` (iOS 16 /
+  macOS 13+) so avatars work with `ShareLink`, drag-and-drop, and paste as a PNG,
+  plus a `ResolvedHumation.pngData(pixels:shape:)` convenience that renders
+  against the bundled manifest.
 
 ## 1.1.0 - 2026-07-05
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ let png = HumationRenderer.pngData(
 )
 ```
 
+### Sharing
+
+`ResolvedHumation` conforms to `Transferable` (iOS 16 / macOS 13+), so avatars
+drop straight into a share sheet, drag session, or pasteboard as a PNG. There's
+also a `pngData()` convenience that renders against the bundled manifest:
+
+```swift
+ShareLink(item: resolved, preview: .init("My avatar"))   // exports a 512px PNG
+
+let png = resolved.pngData(pixels: 256, shape: .circle)  // Data?
+```
+
 ## Built-in editor
 
 `HumationEditor` is an optional product with a ready-made avatar builder. Add it
@@ -151,7 +163,7 @@ pull in `HumationEditor` if you use it.
 | `Humation` | Facade: `prewarm()`, `manifest`, `randomProfile()`, seed **or profile** → `image` / `cgImage` / `nsImage` / `resolved` |
 | `HumationProfile` | `Codable` / `Sendable` avatar wire format (selections + colours) with healing on resolve; `random(in:using:)` |
 | `HumationManifest` / `HumationManifestStore` | Asset manifest model + bundled `humation-1` loader |
-| `HumationTraits` → `ResolvedHumation` | Input design (seed + overrides) resolved to concrete parts + colours |
+| `HumationTraits` → `ResolvedHumation` | Input design resolved to concrete parts + colours; `Transferable` + `pngData()` for sharing |
 | `HumationRenderer` | `render` / `pngData` → `CGImage` / `Data` (`shape: .square` \| `.circle`), `image` / `nsImage`, `contentBounds(of:in:)` |
 | `HumationAvatarView` | SwiftUI view — cached bitmap, cross-platform; `init(seed:…)` / `init(profile:…)` convenience |
 | `HumationEditorView` | Avatar builder UI (in the optional `HumationEditor` product) |

--- a/Sources/Humation/Model/HumationTransferable.swift
+++ b/Sources/Humation/Model/HumationTransferable.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+// MARK: - PNG export
+//
+// A direct-to-bytes convenience so callers can hand an avatar to the share
+// sheet, a drag session, or any API that wants image `Data` without reaching for
+// the manifest themselves.
+
+extension ResolvedHumation {
+    /// PNG bytes for this design rendered against the bundled manifest, or `nil`
+    /// if the manifest is unavailable.
+    public func pngData(pixels: Int = 512, shape: HumationAvatarShape = .square) -> Data? {
+        guard let manifest = HumationManifestStore.shared else { return nil }
+        return HumationRenderer.pngData(
+            resolved: self, manifest: manifest, pixels: pixels, shape: shape
+        )
+    }
+}
+
+// MARK: - Transferable
+//
+// Conforming `ResolvedHumation` to `Transferable` makes avatars work out of the
+// box with `ShareLink(item:)`, drag-and-drop, and copy/paste — the item exports
+// as a 512px square PNG. Gated to the OS versions where `Transferable` exists
+// (the package itself still deploys back to iOS 15 / macOS 12).
+
+#if canImport(CoreTransferable)
+import CoreTransferable
+import UniformTypeIdentifiers
+
+/// Error surfaced when a `Transferable` avatar export cannot render (the bundled
+/// manifest is missing).
+public enum HumationExportError: Error, Sendable {
+    case renderingUnavailable
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, visionOS 1.0, *)
+extension ResolvedHumation: Transferable {
+    public static var transferRepresentation: some TransferRepresentation {
+        DataRepresentation(exportedContentType: .png) { resolved in
+            guard let data = resolved.pngData() else {
+                throw HumationExportError.renderingUnavailable
+            }
+            return data
+        }
+        .suggestedFileName("avatar.png")
+    }
+}
+#endif

--- a/Tests/HumationTests/HumationTransferableTests.swift
+++ b/Tests/HumationTests/HumationTransferableTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+@testable import Humation
+
+#if canImport(CoreTransferable)
+import CoreTransferable
+#endif
+
+final class HumationTransferableTests: XCTestCase {
+
+    private func sampleResolved() throws -> ResolvedHumation {
+        let manifest = try XCTUnwrap(HumationManifestStore.shared)
+        return HumationTraits(seed: "transfer-test").resolved(against: manifest)
+    }
+
+    func testPNGDataProducesValidPNG() throws {
+        let data = try XCTUnwrap(sampleResolved().pngData(pixels: 64))
+        // PNG magic number: 89 50 4E 47 ("\x89PNG").
+        XCTAssertEqual(Array(data.prefix(4)), [0x89, 0x50, 0x4E, 0x47])
+        XCTAssertGreaterThan(data.count, 8)
+    }
+
+    func testPNGDataCircleShapeAlsoRenders() throws {
+        let data = try XCTUnwrap(sampleResolved().pngData(pixels: 64, shape: .circle))
+        XCTAssertEqual(Array(data.prefix(4)), [0x89, 0x50, 0x4E, 0x47])
+    }
+
+    #if canImport(CoreTransferable)
+    @available(iOS 16.0, macOS 13.0, tvOS 16.0, visionOS 1.0, *)
+    func testResolvedHumationIsTransferable() {
+        // Compile-time proof that the conformance exists (so ShareLink(item:) works).
+        func requireTransferable<T: Transferable>(_: T.Type) {}
+        requireTransferable(ResolvedHumation.self)
+    }
+    #endif
+}


### PR DESCRIPTION
## What

Makes avatars shareable with one conformance.

- **`ResolvedHumation: Transferable`** (iOS 16 / macOS 13+) — exports a 512px PNG, so avatars drop straight into `ShareLink(item:)`, drag-and-drop, and paste. Availability-gated so the package still deploys to iOS 15 / macOS 12.
- **`ResolvedHumation.pngData(pixels:shape:)`** — renders PNG bytes against the bundled manifest without the caller reaching for the manifest. Always available; also backs the `Transferable` export.

```swift
ShareLink(item: resolved, preview: .init("My avatar"))   // 512px PNG
let png = resolved.pngData(pixels: 256, shape: .circle)  // Data?
```

## Tests
`HumationTransferableTests`: valid PNG payload (magic bytes) for square + circle, and a compile-time conformance check. `swift build` + `swift test` green locally.

## Notes
- Purely additive; no existing signatures change.
- Independent of #5 (branches off `main`). Both touch the README API table, so a trivial merge order may apply.